### PR TITLE
Fix typo in element in footer of default.html

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -46,7 +46,7 @@
 <aside>
   <form action="https://formspree.io/fiatjaf@gmail.com" method=POST>
     <input type="text" name="_replyto" placeholder="Your email.">
-    <textarea name="message" placeholder="Your message." rows="4"><textarea>
+    <textarea name="message" placeholder="Your message." rows="4"></textarea>
   </form>
 </aside>
 <footer>Using Classless Theme <a href="https://github.com/websitesfortrello/classless/tree/gh-pages/themes/barbieri">Barbieri</a></footer>


### PR DESCRIPTION
A missing 'closing-tag' of the feedback-form breaks the layout of the page-footer.